### PR TITLE
add --recursive parameter to installation page

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -14,7 +14,7 @@ https://www.vagrantup.com/ .
 To begin setting up the example cluster, use ``git`` to check out a
 copy of the source repository for this guide::
 
-  $ git clone git@github.com:krig/hawk-guide
+  $ git clone --recursive git@github.com:krig/hawk-guide
 
 Now let Vagrant configure a virtual machine [#provider]_ running Hawk::
 


### PR DESCRIPTION
this project use `git submodules` for `chef recipes`, the installation page is missing information about initializing the submodules. This patch adds recursive parameter to git clone for automatic submodule initialization.